### PR TITLE
Update block.php

### DIFF
--- a/inc/block.php
+++ b/inc/block.php
@@ -53,7 +53,12 @@ function render( $attributes, $content, $block ) {
 	}
 
 	if ( empty( $post_terms ) ) {
-		return get_taxonomy( $attributes['term'] )->labels->no_terms ?? __( 'Term items not found.', 'taxonomyblock' );
+		if ( $is_preview ) {
+	 		return get_taxonomy( $attributes['term'] )->labels->no_terms ?? __( 'Term items not found.', 'taxonomyblock' );
+	        }
+		else {
+ 			return '';
+		}
 	}
 
 	$classes = 'taxonomy-' . $attributes['term'];


### PR DESCRIPTION
Currently the plugin outputs on the front-end that no matches for a certain taxonomy were found. My suggestion is that instead we only get that feedback inside the page editor - and on the front-end we output nothing if no match for the taxonomy was found. It is common that you may have a custom post type with some custom taxonomy and terms but only some posts have the terms, and others do not have any at all. Especially at the point where you add a new custom taxonomy and terms but have not managed to assign them appropriately to all of your existing custom posts.